### PR TITLE
Update project model to match api

### DIFF
--- a/lib/src/models/project.dart
+++ b/lib/src/models/project.dart
@@ -16,7 +16,7 @@ class Project {
   String owner_uuid;
 
   /// The integer id of the project owner.
-  String owner_id;
+  int owner_id;
 
   /// The human-readable name for the project. The maximum length is 175 characters and the name must be unique.
   String name;

--- a/lib/src/models/project.g.dart
+++ b/lib/src/models/project.g.dart
@@ -10,7 +10,7 @@ Project _$ProjectFromJson(Map<String, dynamic> json) {
   return Project(
       json['id'] as String,
       json['owner_uuid'] as String,
-      json['owner_id'] as String,
+      json['owner_id'] as int,
       json['name'] as String,
       json['description'] as String,
       json['purpose'] as String,


### PR DESCRIPTION
Hello!
There is a mismatch between library Project model and actual api. 'owner_id' field should be int.
This mismatch breaks fetching list of projects and other related requests